### PR TITLE
Support Emacs 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Screenshot:
 ## Installation
 
 0. Dependencies:
-Emacs 28.1+ with the following packages installed:
+Emacs 27 (or, better, 28.1+) with the following packages installed:
  - [`tree-sitter`](https://emacs-tree-sitter.github.io/installation/)
  - [`tsi.el`](https://github.com/orzechowskid/tsi.el)
  - [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode)
  - [`company`](https://github.com/company-mode/company-mode)
  - [`origami.el`](https://github.com/gregsexton/origami.el)
 1. Install: download this package and place `tsx-mode.el` inside a directory on your `load-path`.
-  
+
 > or install this repository (and all its package dependencies) via `straight.el`: `(straight-use-package '(tsx-mode :type git :host github :repo "orzechowskid/tsx-mode.el"))`
 2. Require: `(require 'tsx-mode)`
 3. Enable: `(tsx-mode t)`
@@ -42,6 +42,8 @@ tons!
 - TS/TSX indentation might not be quite right.  (if you notice something, please open an issue against [tsi.el](https://github.com/orzechowskid/tsi.el))
 - CSS indentation might not be quite right either.  (if you notice something, please open an issue against this repo)
 - only a couple of CSS-in-JS formats are currently supported.
+- CSS fontification relies on a feature introduced in Emacs 28.1, so
+  on Emacs 27 CSS fragments won't be fontified.
 
 ## License
 

--- a/tsx-mode.el
+++ b/tsx-mode.el
@@ -10,10 +10,6 @@
 
 ;;; Code:
 
-(unless (fboundp 'object-intervals)
-  (error "Unsupported: tsx-mode.el requires Emacs 28.1+"))
-
-
 (require 'css-mode)
 (require 'js)
 (require 'seq)
@@ -30,6 +26,8 @@
 (require 'tsi-css)
 (require 'tsi-typescript)
 
+(unless (fboundp 'object-intervals)
+  (message "tsx-mode CSS fontification requires Emacs 28.1+, so we will do without it"))
 
 (defgroup tsx-mode nil
   "Major mode for JSX webapp files."
@@ -241,6 +239,10 @@ Perform just-in-time text propertization from BEG to END in the current buffer."
     . ,(max end (or (plist-get tsx-mode--current-css-region :region-end) (point-min)))))
 
 
+(defun maybe-object-intervals (obj)
+  (if (fboundp 'object-intervals)
+      (object-intervals obj)))
+
 (defun tsx-mode--fontify-current-css-region ()
   "Internal function.
 
@@ -266,7 +268,7 @@ properties back to this buffer."
         (tree-sitter--after-change (point-min) (point-max) 0)
         (font-lock-ensure (point-min) (point-max)))
       (setq fontified-text-properties-list
-            (object-intervals
+            (maybe-object-intervals
              (buffer-substring
               (+ (length "div{") (point-min))
               (- (point-max) (length "}"))))))
@@ -313,7 +315,7 @@ Run the enter-CSS-region hook with NEW-REGION, then returns NEW-REGION."
   (run-hook-with-args 'tsx-mode-css-enter-region-hook new-region)
   new-region)
 
-  
+
 (defun tsx-mode--do-css-region-exit (old-region)
   "Internal function.
 
@@ -322,7 +324,7 @@ Run the exit-CSS-region hook with OLD-REGION, then returns OLD-REGION."
   (run-hook-with-args 'tsx-mode-css-exit-region-hook old-region)
   old-region)
 
-  
+
 (defun tsx-mode--update-current-css-region ()
   "Internal function.
 
@@ -680,7 +682,7 @@ been enabled."
 
 
 ;;;###autoload
-(define-derived-mode 
+(define-derived-mode
     tsx-mode prog-mode "TSX"
     "A batteries-included major mode for JSX and friends."
     :group 'tsx-mode
@@ -711,5 +713,5 @@ been enabled."
     (lsp)
     (lsp-completion-mode t))
 
-    
+
 (provide 'tsx-mode)


### PR DESCRIPTION
object-intervals is an Emacs 28.1+ feature, so the effect of this
change is to make tsx-mode work on Emacs 27, but without CSS
fontification.