### PR TITLE
down-bump emacs version requirement now that object-intervals is optional

### DIFF
--- a/tsx-mode.el
+++ b/tsx-mode.el
@@ -6,7 +6,7 @@
 
 ;;; URL: https://github.com/orzechowskid/tsx-mode.el
 
-;;; Package-Requires: ((emacs "28.1") (tsi "1.0.0") (tree-sitter-langs "0.11.3") (lsp-mode "8.0.0") (origami "1.0"))
+;;; Package-Requires: ((emacs "27") (tsi "1.0.0") (tree-sitter-langs "0.11.3") (lsp-mode "8.0.0") (origami "1.0"))
 
 ;;; Code:
 


### PR DESCRIPTION
fixes #22 