### PR TITLE
derive origami nodes from tree-sitter queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Emacs 27 (or, better, 28.1+) with the following packages installed:
 
 all tsx-mode keybindings live under the `C-c t` prefix.
 
-| Binding   | Command                                          | Function                       |
-| --        | --                                               | ---                            |
-| `C-c t f` | toggle code-folding for current CSS-in-JS region | `tsx-mode-css-toggle-fold`     |
-| `C-c t F` | toggle code-folding for all CSS-in-JS regions    | `tsx-mode-css-toggle-fold-all` |
-| `C-c t c` | toggle code-coverage overlay                     | `tsx-mode-coverage-toggle`     |
+| Binding   | Command                                | Function                   |
+| --        | --                                     | --                         |
+| `C-c t f` | toggle code-folding for current region | `origami-toggle-node`      |
+| `C-c t F` | toggle code-folding for all regions    | `origami-toggle-all-nodes` |
+| `C-c t c` | toggle code-coverage overlay           | `tsx-mode-coverage-toggle` |
 
 ## Configuration
 

--- a/tsx-mode.el
+++ b/tsx-mode.el
@@ -139,13 +139,6 @@ CSS-in-JS region containing point (if any).")
 Plist of all CSS-in-JS regions in this buffer.")
 
 
-(defvar-local tsx-mode--ts-query-cursor
-    nil
-  "Internal variable.
-
-Cursor for tree-sitter queries.")
-
-
 (defun tsx-mode--css-inline-style-at-pos-p (pos)
   "Internal function.
 

--- a/tsx-mode.el
+++ b/tsx-mode.el
@@ -534,6 +534,9 @@ is."
 
 
 (defun tsx-mode--origami-query (query-root-node)
+  "Internal function.
+
+Run the user's fold queries on a subtree with root at QUERY-ROOT-NODE."
   (mapcar 'cdr
           (tsc-query-captures
            (tsc-make-query
@@ -544,6 +547,9 @@ is."
 
 
 (defun tsx-mode--origami-fold (node create)
+  "Internal function.
+
+Create an Origami fold node (with children) from the provided tree-sitter NODE."
   (let ((child-nodes (cdr (tsx-mode--origami-query node))))
     (funcall create
              (tsc-node-start-position node)
@@ -556,6 +562,9 @@ is."
 
 
 (defun tsx-mode--origami-parser (create)
+  "Internal function.
+
+Return a function suitable for use as an Origami parser."
   (lambda (content)
     (mapcar
      (lambda (elt)


### PR DESCRIPTION
should address #28 .

there's a new `defcustom` called `tsx-mode-fold-tree-queries` which is a list of strings corresponding to tree-sitter query patterns targeting nodes to fold.  the default value for this variable is:
```
'("(function_declaration (statement_block) @fb)" ; allows folding of the statement block belonging to a function declaration
  "(call_expression (template_string) @ts)")     ; allows folding of the template string belonging to a tagged template
```

to add new queries to this list, enable `tree-sitter-debug-mode` in a JS/TS buffer to see the CST then call `tree-sitter-query-builder` to open the query-builder playground.  fiddle around until your query selects what you want it to select.  a query format reference can be found here: https://tree-sitter.github.io/tree-sitter/using-parsers#query-syntax .  make sure to annotate the captured node with an `@at-rule` annotation to give it a name, or else tree-sitter won't know how to build its alist.  (the name itself doesn't really matter; it just has to exist)

this is a breaking change; semver has been updated accordingly.